### PR TITLE
adding sign up and sign in forms

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -56,3 +56,4 @@ unattended-upgrades==0.1
 urllib3==1.22
 Werkzeug==1.0.1
 zope.interface==4.3.2
+flask_wtf==0.14.3

--- a/tutor/controllers/forms.py
+++ b/tutor/controllers/forms.py
@@ -1,0 +1,22 @@
+from flask_wtf import FlaskForm
+from wtforms import StringField, PasswordField, SubmitField, BooleanField, FloatField
+from wtforms.validators import DataRequired, Length, EqualTo, InputRequired
+
+class RegistrationForm(FlaskForm):
+    username = StringField('Username',
+                validators=[DataRequired(), Length(min=2, max=20)])
+    email = StringField('Email',
+                validators=[DataRequired(), Length(min=2, max=20)])
+    password = PasswordField('Password',
+                validators=[DataRequired(), Length(min=3, max=15)])
+    confirm_password = PasswordField('Confirm Password',
+                validators=[DataRequired(), EqualTo('password')])
+    submit = SubmitField('Sign Up')
+
+class LoginForm(FlaskForm):
+    email = StringField('Email',
+                validators=[DataRequired()])
+    password = PasswordField('Password',
+                validators=[DataRequired()])
+    remember = BooleanField('Remeber Me')
+    submit = SubmitField('Login')

--- a/tutor/controllers/login.py
+++ b/tutor/controllers/login.py
@@ -1,0 +1,8 @@
+from flask import Flask, Response, render_template, request, redirect, url_for
+from forms import RegistrationForm, LoginForm
+
+def login():
+    form = LoginForm()
+    if form.validate_on_submit():
+        return redirect(url_for('home'))
+    return render_template('login.html', form=form)

--- a/tutor/controllers/register.py
+++ b/tutor/controllers/register.py
@@ -1,0 +1,8 @@
+from flask import Flask, Response, render_template, request, redirect, url_for
+from forms import RegistrationForm, LoginForm
+
+def register():
+    form = RegistrationForm()
+    if form.validate_on_submit():
+        return redirect(url_for('home'))
+    return render_template('register.html', form=form)

--- a/tutor/routes/home.py
+++ b/tutor/routes/home.py
@@ -1,7 +1,19 @@
 from .. import app
-from ..controllers import home
+from ..controllers import home, register, login, forms
 
 
 @app.route('/')
 def index_route():
     return home.home()
+
+@app.route("/home")
+def home():
+    return home.home()
+
+@app.route("/register", methods=[ 'GET', 'POST']) 
+def register():
+    return register.register()
+
+@app.route("/login", methods=['GET', 'POST'])
+def login():
+    return login.login()

--- a/tutor/templates/base.html
+++ b/tutor/templates/base.html
@@ -10,7 +10,7 @@
     <body style="background: url(../static/img/pexels-lukas-317356.jpg); background-size: cover">  
 
         <nav class="navbar navbar-expand-lg navbar-light bg-light" style="background: url(../static/img/pexels-lukas-317356.jpg); background-size: cover" >
-          <a href="/"><img src="../static/img/logo.jpeg" width=82 height=42></a>
+          <a href="{{ url_for('home') }}"><img src="../static/img/logo.jpeg" width=82 height=42></a>
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
               <span class="navbar-toggler-icon"></span>
             </button>
@@ -22,15 +22,19 @@
                 </li>
               </ul>
               <div class="my-2 my-lg-0">
-                <a class="nav-link border" style="background-color: white" href="#">Sign up</a>
+                <a class="nav-link border" style="background-color: white" href="{{ url_for('register') }}">Sign up</a>
+              </div>
+              <div class="my-2 my-lg-0">
+                <a class="nav-link border" style="background-color: white" href="{{ url_for('login') }}">Log in</a>
               </div>
             </div>
           </nav>
 
           <div class="container">
+            <div class="jumbotron" style="background-color: white; opacity: 0.95;">  
             {% block content%} {% endblock %}
+            </div>
           </div>
-        
       </div>
         <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" 
         integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>

--- a/tutor/templates/index.html
+++ b/tutor/templates/index.html
@@ -2,14 +2,13 @@
 {% block title %} Tutor {% endblock %}
 
 {% block content %}
-     
-<div class="jumbotron" style="opacity: 0.8; margin-top: 75px">
-    <h1 class="display-4" style="font-weight: bold;"><strong>Tutor - Sharing Towards Excellence</strong></h1>
-    <p style="font-size: 25px; margin-top: 25px">Tutor is an open-source platform for students, made by students, to make their studies more efficient, easy and enjoyable.
+    
+    <h2 class="display-4" style="font-weight: bold;"><strong>Tutor - Sharing Towards Excellence</strong></h2>
+    <p style="font-size: 20px; margin-top: 25px">Tutor is an open-source platform for students, made by students, to make their studies more efficient, easy and enjoyable.
         Using Tutor you get helpful sources about various courses,
         like videos, summaries, links, and have all the information you need to excel in every course. 
 <br>You can also share with others the materials that helped you succeed in your studies.</p>
-</div>
+
  
 
 {% endblock %}

--- a/tutor/templates/login.html
+++ b/tutor/templates/login.html
@@ -1,0 +1,52 @@
+{% extends "base.html" %}
+{% block title %} Tutor-login {% endblock %}
+
+{% block content %}
+    <div class="content-section">
+        <form method="POST" action="">
+            {{ form.hidden_tag() }}
+            <fieldset class="form-group">
+                <legend class="border-bottom mb-4">Log In</legend>
+                <div class="form-group">
+                    {{ form.email.label(class="form-control-label") }}
+                    {% if form.email.errors %}
+                        {{ form.email(class="form-control form-control-lg is-invalid") }}
+                        <div class="invalid-feedback">
+                            {% for error in form.email.errors %}
+                                <span>{{ error }}</span>
+                            {% endfor %}
+                        </div>
+                    {% else %}
+                        {{ form.email(class="form-control form-control-lg") }}
+                    {% endif %}
+                </div>
+                <div class="form-group">
+                    {{ form.password.label(class="form-control-label") }}
+                    {% if form.password.errors %}
+                        {{ form.password(class="form-control form-control-lg is-invalid") }}
+                        <div class="invalid-feedback">
+                            {% for error in form.password.errors %}
+                                <span>{{ error }}</span>
+                            {% endfor %}
+                        </div>
+                    {% else %}
+                        {{ form.password(class="form-control form-control-lg") }}
+                    {% endif %}
+                </div>
+                <div class="form-check">
+                    {{ form.remember(class="form-check-input") }}
+                    {{ form.remember.label(class="form-check-label") }}
+                </div>
+            </fieldset>
+            <div class="form-group">
+                {{ form.submit(class="btn btn-outline-info") }}
+            </div>
+            <small class="text-muted ml-2">
+                <a href="#">Forgot Password?</a>
+            </small>
+        </form>
+    </div>
+    <div class="border-top pt-3">
+            Don't have An Account? <a class="ml-2" href="{{ url_for('register') }}">Sign Up</a>
+    </div>
+{% endblock content %}

--- a/tutor/templates/register.html
+++ b/tutor/templates/register.html
@@ -1,0 +1,74 @@
+{% extends "base.html" %}
+{% block title %} Tutor-Register {% endblock %}
+
+{% block content %}
+
+    <div class="content-section">
+        <form method="POST" action="">
+            {{ form.hidden_tag() }}
+            <fieldset class="form-group">
+                <legend class="border-bottom mb-4">Join Tutor</legend>
+                <div class="form-group">
+                    {{ form.username.label(class="form-control-label") }}
+
+                    {% if form.username.errors %}
+                        {{ form.username(class="form-control form-control-lg is-invalid") }}
+                        <div class="invalid-feedback">
+                            {% for error in form.username.errors %}
+                                <span>{{ error }}</span>
+                            {% endfor %}
+                        </div>
+                    {% else %}
+                        {{ form.username(class="form-control form-control-lg") }}
+                    {% endif %}
+                </div>
+                <div class="form-group">
+                    {{ form.email.label(class="form-control-label") }}
+                    {% if form.email.errors %}
+                        {{ form.email(class="form-control form-control-lg is-invalid") }}
+                        <div class="invalid-feedback">
+                            {% for error in form.email.errors %}
+                                <span>{{ error }}</span>
+                            {% endfor %}
+                        </div>
+                    {% else %}
+                        {{ form.email(class="form-control form-control-lg") }}
+                    {% endif %}
+                </div>
+                <div class="form-group">
+                    {{ form.password.label(class="form-control-label") }}
+                    {% if form.password.errors %}
+                        {{ form.password(class="form-control form-control-lg is-invalid") }}
+                        <div class="invalid-feedback">
+                            {% for error in form.password.errors %}
+                                <span>{{ error }}</span>
+                            {% endfor %}
+                        </div>
+                    {% else %}
+                        {{ form.password(class="form-control form-control-lg") }}
+                    {% endif %}
+                </div>
+                <div class="form-group">
+                    {{ form.confirm_password.label(class="form-control-label") }}
+                    {% if form.confirm_password.errors %}
+                        {{ form.confirm_password(class="form-control form-control-lg is-invalid") }}
+                        <div class="invalid-feedback">
+                            {% for error in form.confirm_password.errors %}
+                                <span>{{ error }}</span>
+                            {% endfor %}
+                        </div>
+                    {% else %}
+                        {{ form.confirm_password(class="form-control form-control-lg") }}
+                    {% endif %}
+                </div>
+            </fieldset>
+            <div class="form-group">
+                {{ form.submit(class="btn btn-outline-info") }}
+            </div>
+        </form>
+    </div>
+    <div class="border-top pt-3">
+            Already Have A Tutor Account? <a class="ml-2" href="{{ url_for('login') }}">Sign In</a>
+    </div>
+
+{% endblock content %}


### PR DESCRIPTION
this PR is related to issue #13 
new files added:
-register.py - creating register form 
-login.py  - creating log in form
-register.html - 
-login.html
-forms.py - defining the fields of the register and login forms and includes validation of input

files where I added slight changes:
-requirements : added the flask-wtf import
-routes.home - added the routing to register and login
-base.html:
 - changed the anchor tags in the navigate bar to lead to the register and login pages and not just be '#'
 - moved the jumbotron design from index.html to base.html so it will be applied on all pages, now that there are the additional register and login and not just home page. 

![image](https://user-images.githubusercontent.com/64838275/92224097-0a20e380-eeaa-11ea-8d02-45a069ac70ff.png)

![image](https://user-images.githubusercontent.com/64838275/92224197-27ee4880-eeaa-11ea-992b-4789d986af9f.png)


