### PR TITLE
fixed pipenv

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -8,6 +8,7 @@ apt install -y python3.7 python3-pip python3.7-dev postgresql postgresql-contrib
 
 echo "installing dependencies"
 pip3 install pipenv
+export PIPENV_VENV_IN_PROJECT="enabled"
 cd /vagrant/ && pipenv sync --dev
 
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -9,6 +9,7 @@ apt install -y python3.7 python3-pip python3.7-dev postgresql postgresql-contrib
 echo "installing dependencies"
 pip3 install pipenv
 export PIPENV_VENV_IN_PROJECT="enabled"
+export VIRTUALENV_ALWAYS_COPY=1
 cd /vagrant/ && pipenv sync --dev
 
 


### PR DESCRIPTION
pipenv is creating the environment under root user.
This means that when ssh into the machine, we cannot access the environment because we are logging in as vagrant user.
This added variable in bootstrap.sh file makes sure we can access the environment as vagrant user and make changes to it